### PR TITLE
[MI-1420]: Created API to archive/unarchive channels

### DIFF
--- a/server/constants/urls.go
+++ b/server/constants/urls.go
@@ -3,6 +3,8 @@ package constants
 const (
 	PathTest                 = "/test"
 	CreateChannel            = "/channels"
+	ArchiveChannel           = "/channels/{channel_id:[A-Za-z0-9]+}"
+	UnarchiveChannel         = "/channels/{channel_id:[A-Za-z0-9]+}/unarchive"
 	GetOrCreateUserInTeam    = "/users"
 	UpdateUser               = "/users/{user_id:[A-Za-z0-9]+}"
 	GetUserByEmail           = "/users/{email}"


### PR DESCRIPTION
Created API to archive/unarchive channels using Mattermost plugin API

1. For archiving, used "DeleteChannel" plugin API provided by Mattermost, it soft deletes a channels.
2. For unarchiving, used "UpdateChannel" where setting "DeletedAt" field to 0 which unarchives the channel.